### PR TITLE
Add Refinements#all method (to assist in loading all patches)

### DIFF
--- a/lib/refinements.rb
+++ b/lib/refinements.rb
@@ -5,3 +5,15 @@ require "refinements/big_decimals"
 require "refinements/hashes"
 require "refinements/identity"
 require "refinements/strings"
+
+module Refinements
+  def self.all
+    [
+      Refinements::Arrays,
+      Refinements::BigDecimals,
+      Refinements::Hashes,
+      Refinements::Identity,
+      Refinements::Strings
+    ]
+  end
+end


### PR DESCRIPTION
With this added method, you can now do this:

```rb
class MyClass
  Refinements.all.each { |patch| using patch }
end
```

It's a quick way to load all patches. `using` has a lot of restrictions, but it can still be called in a loop and can still be passed a variable (pointing to a module). This is basically taking advantage of that.

## Overview
<!-- Required. Why is this important/necessary? -->

## Details
<!-- Optional. List the key features/highlights as bullet points. -->

## Notes
<!-- Optional. List additional notes/references as bullet points. Delete if unused. -->

## Screenshots/Screencasts
<!-- Optional. Provide image/video support. Delete if unused. -->
