### PR TITLE
Fix error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The following sections demonstrate how each refinement enriches your objects wit
     "example".first 4 # => "exam"
 
     "instant".last # => "t"
-    "instant".first 3 # => "ant"
+    "instant".last 3 # => "ant"
 
     " \n\t\r".blank? # => true
     "example".up # => "Example"


### PR DESCRIPTION
One of the examples in the README was using `String#first` to show off the behaviour of `String#last`.

## Overview
This makes the example make sense. Which looks neater and can lessen confusion for newer developers.