### PR TITLE
Fixed Array compress documentation to include bang suffix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,8 +148,8 @@ Removes `nil` and empty values while mutating itself.
 object = Object.new
 example = [1, "blueberry", nil, "", [], {}, object]
 
-example.compress  # [1, "blueberry", object]
-example           # [1, "blueberry", object]
+example.compress!  # [1, "blueberry", object]
+example            # [1, "blueberry", object]
 ----
 
 ===== #excluding


### PR DESCRIPTION
## Overview

This pull requests adds a missing exclamation mark to the documentation.
